### PR TITLE
Add basic IP-based rate limiting with Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       POSTGRES_HOST: ${POSTGRES_HOST}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      REDIS_HOST: redis
       GOOGLE_APPLICATION_CREDENTIALS: /gcs-sa.json
 
   postgres:
@@ -25,6 +26,12 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - 6379:6379
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       REDIS_HOST: redis
       GOOGLE_APPLICATION_CREDENTIALS: /gcs-sa.json
+    command: bash -c "sleep 10; npm start"
+
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - 6379:6379
 
   postgres:
     image: postgres:latest
@@ -26,12 +33,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-
-  redis:
-    image: redis:latest
-    restart: always
-    ports:
-      - 6379:6379
 
 volumes:
   postgres-data:

--- a/lib/rateLimit.js
+++ b/lib/rateLimit.js
@@ -1,0 +1,23 @@
+const { promisify } = require('util')
+const { redisClient } = require('./redis')
+
+const incrAsync = promisify(redisClient.incr).bind(redisClient)
+
+module.exports = (maxReqPerMinute) => {
+  return async (req, res, next) => {
+    const date = new Date()
+    const key = `${req.ip}:${date.getHours()}${date.getMinutes()}`
+    const reqCount = await incrAsync(key)
+    if (reqCount == 1) {
+      await redisClient.expire(key, 60)
+    }
+
+    if (reqCount > maxReqPerMinute) {
+      res.status(429).send({
+        error: 'Too many requests sent this minute.'
+      })
+    } else {
+      next()
+    }
+  }
+}

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,0 +1,7 @@
+const redis = require('redis')
+const redisClient = redis.createClient({
+  host: process.env.REDIS_HOST,
+  port: process.env.REDIS_PORT || 6379
+})
+
+exports.redisClient = redisClient

--- a/package-lock.json
+++ b/package-lock.json
@@ -830,6 +830,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -3016,6 +3021,26 @@
           }
         }
       }
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "express": "^4.17.0",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",
-    "pg": "^7.11.0"
+    "pg": "^7.11.0",
+    "redis": "^2.8.0"
   },
   "devDependencies": {
     "nodemon": "^1.19.0"

--- a/server.js
+++ b/server.js
@@ -11,8 +11,12 @@ const { Course } = require('./models/course')
 const { CourseStudent } = require('./models/courseStudent')
 const { User } = require('./models/user')
 
+const rateLimit = require('./lib/rateLimit')
+
 const app = express();
 const port = process.env.PORT || 8000;
+
+app.use(rateLimit(30))
 
 /*
  * Morgan is a popular logger.


### PR DESCRIPTION
Be aware that the api container starts on a 10-second delay now. After adding the redis container, the API server connected to the postgres container before it fully came up. Despite the restart: always setting, the api container didn't restart.